### PR TITLE
Fixing TimeSpan formatting to match API expectations.

### DIFF
--- a/lib/application_insights/rack/track_request.rb
+++ b/lib/application_insights/rack/track_request.rb
@@ -74,10 +74,10 @@ module ApplicationInsights
       def format_request_duration(duration_seconds)
         if duration_seconds >= 86400
           # just return 1 day when it takes more than 1 day which should not happen for requests.
-          return "%d:%02d:%02d:%02d.%07d" % [1, 0, 0, 0, 0]
+          return "%d.%02d:%02d:%02d.%07d" % [1, 0, 0, 0, 0]
         end
 
-        Time.at(duration_seconds).gmtime.strftime("0:%H:%M:%S.%7N")
+        Time.at(duration_seconds).gmtime.strftime("0.%H:%M:%S.%7N")
       end
     end
   end

--- a/test/application_insights/rack/test_track_request.rb
+++ b/test/application_insights/rack/test_track_request.rb
@@ -6,6 +6,9 @@ require_relative '../../../lib/application_insights/rack/track_request'
 include ApplicationInsights::Rack
 
 class TestTrackRequest < Test::Unit::TestCase
+
+  TIME_SPAN_FORMAT = /^(?<day>\d{1})\.(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}).(?<fraction>\d{7})$/
+
   def test_call_works_as_expected
     response_code = rand(200..204)
     app = Proc.new {|env| sleep(2); [response_code, {"Content-Type" => "text/html"}, ["Hello Rack!"]]}
@@ -31,7 +34,7 @@ class TestTrackRequest < Test::Unit::TestCase
     assert_equal true, request_data.success
     assert_equal http_method, request_data.http_method
     assert_equal url, request_data.url
-    assert_equal true, request_data.duration.start_with?("0:00:00:02")
+    assert_equal true, request_data.duration.start_with?("0.00:00:02")
     assert Time.parse(request_data.start_time) - start_time < 0.01
   end
 
@@ -107,8 +110,8 @@ class TestTrackRequest < Test::Unit::TestCase
     track_request = TrackRequest.new app, 'one'
     duration_seconds = rand(86400) + rand
     time_span = track_request.send(:format_request_duration, duration_seconds)
-    time_span_format = /^(?<day>\d{1}):(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}).(?<fraction>\d{7})$/
-    match = time_span_format.match time_span
+    
+    match = TIME_SPAN_FORMAT.match time_span
     assert_not_nil match
     days = duration_seconds.to_i/86400
     assert_equal days, match['day'].to_i
@@ -127,8 +130,8 @@ class TestTrackRequest < Test::Unit::TestCase
     track_request = TrackRequest.new app, 'one'
     duration_seconds = rand(86400..240000) + rand
     time_span = track_request.send(:format_request_duration, duration_seconds)
-    time_span_format = /^(?<day>\d{1}):(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}).(?<fraction>\d{7})$/
-    match = time_span_format.match time_span
+    
+    match = TIME_SPAN_FORMAT.match time_span
     assert_not_nil match
     assert_equal 1, match['day'].to_i
     assert_equal 0, match['hour'].to_i


### PR DESCRIPTION
API expects days to be delimited by a period instead of a colon.
