### PR TITLE
Fix failure on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+  - 2.3.3
+  - 2.4.0
+  - ruby-head
 
 cache: bundler
 
 before_install:
   - gem install bundler
+
+matrix:
+  allow_failures:
+  - rvm: ruby-head
 
 install:
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,10 @@ rvm:
   - 2.1.0
   - 2.2.0
 
+cache: bundler
+
+before_install:
+  - gem install bundler
+
 install:
   - bundle install


### PR DESCRIPTION
* [Build #38 - Microsoft/ApplicationInsights-Ruby - Travis CI](https://travis-ci.org/Microsoft/ApplicationInsights-Ruby/builds/121000818)

Tests could not start in ruby 1.9.3 and ruby 2.2.0 at the HEAD of the master branch. I found it was caused by bundler's issue on travis CI. 

This PR provides an update on `.travis.yaml` so that bundler is installed before executing a test script to avoid the issue. 
