### PR TITLE
Fix automatic request tracking

### DIFF
--- a/lib/application_insights/rack/track_request.rb
+++ b/lib/application_insights/rack/track_request.rb
@@ -78,10 +78,10 @@ module ApplicationInsights
         if duration_seconds >= 86_400
           # just return 1 day when it takes more than 1 day which should not
           # happen for requests.
-          return "%d:%02d:%02d:%02d.%07d" % [1, 0, 0, 0, 0]
+          return "%02d.%02d:%02d:%02d.%07d" % [1, 0, 0, 0, 0]
         end
 
-        Time.at(duration_seconds).gmtime.strftime("0:%H:%M:%S.%7N")
+        Time.at(duration_seconds).gmtime.strftime("00.%H:%M:%S.%7N")
       end
     end
   end

--- a/test/application_insights/channel/contracts/test_exception_details.rb
+++ b/test/application_insights/channel/contracts/test_exception_details.rb
@@ -58,7 +58,7 @@ class TestExceptionDetails < Test::Unit::TestCase
   end
 
   def test_has_full_stack_works_as_expected
-    expected = TRUE
+    expected = true
     item = Contracts::ExceptionDetails.new
     item.has_full_stack = expected
     actual = item.has_full_stack
@@ -93,7 +93,7 @@ class TestExceptionDetails < Test::Unit::TestCase
     item.outer_id = 42
     item.type_name = 'Test string'
     item.message = 'Test string'
-    item.has_full_stack = TRUE
+    item.has_full_stack = true
     item.stack = 'Test string'
     [ { 'key' => 'value' } ].each do |value|
       item.parsed_stack.push value

--- a/test/application_insights/channel/contracts/test_remote_dependency_data.rb
+++ b/test/application_insights/channel/contracts/test_remote_dependency_data.rb
@@ -118,7 +118,7 @@ class TestRemoteDependencyData < Test::Unit::TestCase
   end
 
   def test_success_works_as_expected
-    expected = TRUE
+    expected = true
     item = Contracts::RemoteDependencyData.new
     item.success = expected
     actual = item.success
@@ -130,7 +130,7 @@ class TestRemoteDependencyData < Test::Unit::TestCase
   end
 
   def test_async_works_as_expected
-    expected = TRUE
+    expected = true
     item = Contracts::RemoteDependencyData.new
     item.async = expected
     actual = item.async
@@ -194,8 +194,8 @@ class TestRemoteDependencyData < Test::Unit::TestCase
     item.max = 1.5
     item.std_dev = 1.5
     item.dependency_kind = 5
-    item.success = TRUE
-    item.async = TRUE
+    item.success = true
+    item.async = true
     item.dependency_source = 5
     item.command_name = 'Test string'
     item.dependency_type_name = 'Test string'

--- a/test/application_insights/channel/contracts/test_request_data.rb
+++ b/test/application_insights/channel/contracts/test_request_data.rb
@@ -82,7 +82,7 @@ class TestRequestData < Test::Unit::TestCase
   end
 
   def test_success_works_as_expected
-    expected = TRUE
+    expected = true
     item = Contracts::RequestData.new
     item.success = expected
     actual = item.success
@@ -137,7 +137,7 @@ class TestRequestData < Test::Unit::TestCase
     item.start_time = 'Test string'
     item.duration = 'Test string'
     item.response_code = 'Test string'
-    item.success = TRUE
+    item.success = true
     item.http_method = 'Test string'
     item.url = 'Test string'
     { 'key1' => 'test value 1' , 'key2' => 'test value 2' }.each do |key, value|

--- a/test/application_insights/channel/test_sender_base.rb
+++ b/test/application_insights/channel/test_sender_base.rb
@@ -61,7 +61,7 @@ class TestSenderBase < Test::Unit::TestCase
       client = server.accept
       request = ''
       read_buffer_size = 64
-      while TRUE
+      while true
         temp = client.recv(read_buffer_size)
         request += temp
         break if temp.length < read_buffer_size

--- a/test/application_insights/rack/test_track_request.rb
+++ b/test/application_insights/rack/test_track_request.rb
@@ -31,7 +31,7 @@ class TestTrackRequest < Test::Unit::TestCase
     assert_equal true, request_data.success
     assert_equal http_method, request_data.http_method
     assert_equal url, request_data.url
-    assert_equal true, request_data.duration.start_with?("0:00:00:02")
+    assert_equal true, request_data.duration.start_with?("00.00:00:02")
     assert Time.parse(request_data.start_time) - start_time < 0.01
   end
 
@@ -107,7 +107,7 @@ class TestTrackRequest < Test::Unit::TestCase
     track_request = TrackRequest.new app, 'one'
     duration_seconds = rand(86400) + rand
     time_span = track_request.send(:format_request_duration, duration_seconds)
-    time_span_format = /^(?<day>\d{1}):(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}).(?<fraction>\d{7})$/
+    time_span_format = /^(?<day>\d{2}).(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}).(?<fraction>\d{7})$/
     match = time_span_format.match time_span
     assert_not_nil match
     days = duration_seconds.to_i/86400
@@ -127,7 +127,7 @@ class TestTrackRequest < Test::Unit::TestCase
     track_request = TrackRequest.new app, 'one'
     duration_seconds = rand(86400..240000) + rand
     time_span = track_request.send(:format_request_duration, duration_seconds)
-    time_span_format = /^(?<day>\d{1}):(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}).(?<fraction>\d{7})$/
+    time_span_format = /^(?<day>\d{2}).(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}).(?<fraction>\d{7})$/
     match = time_span_format.match time_span
     assert_not_nil match
     assert_equal 1, match['day'].to_i


### PR DESCRIPTION
AI reports an error when sending requests currently.  The "duration" field is not in the expected format.  AI expects "dd.hh:mm:ss.fffffff" and the SDK is sending "d:hh:mm:ss.fffffff".

Also updating to use "true" instead of "TRUE" as the "TRUE" constant was deprecated in Ruby 2.4