### PR TITLE
Add track_envelope method to telemetry client

### DIFF
--- a/lib/application_insights/channel/asynchronous_sender.rb
+++ b/lib/application_insights/channel/asynchronous_sender.rb
@@ -122,9 +122,10 @@ module ApplicationInsights
               break
             end
           end
-        rescue
+        rescue Exception => e
           # Make sure work_thread sets to nil when it terminates abnormally
           @work_thread = nil
+          @logger.error('application_insights') { "Asynchronous sender work thread terminated abnormally: #{e.to_s}" }
         end
       end
     end

--- a/lib/application_insights/channel/sender_base.rb
+++ b/lib/application_insights/channel/sender_base.rb
@@ -3,6 +3,7 @@ require 'net/http'
 require 'openssl'
 require 'stringio'
 require 'zlib'
+require 'logger'
 
 module ApplicationInsights
   module Channel
@@ -20,6 +21,7 @@ module ApplicationInsights
         @service_endpoint_uri = service_endpoint_uri
         @queue = nil
         @send_buffer_size = 100
+        @logger = Logger.new(STDOUT)
       end
 
       # The service endpoint URI where this sender will send data to.
@@ -63,6 +65,10 @@ module ApplicationInsights
 
         response = http.request(request)
         http.finish if http.started?
+
+        if !response.kind_of? Net::HTTPSuccess
+          @logger.error('application_insights') { "Failed to send data: #{response.message}" }
+        end
       end
 
       private

--- a/lib/application_insights/channel/telemetry_channel.rb
+++ b/lib/application_insights/channel/telemetry_channel.rb
@@ -61,7 +61,7 @@ module ApplicationInsights
       #   an {Contracts::Envelope} before being enqueued to the {#queue}.
       # @param [TelemetryContext] context the override context to use when
       #   constructing the {Contracts::Envelope}.
-      def write(data, context=nil)
+      def write(data, context=nil, time=nil)
         local_context = context || @context
         raise ArgumentError, 'Context was required but not provided' unless local_context
         data_type = data.class.name.gsub(/^.*::/, '')
@@ -72,7 +72,7 @@ module ApplicationInsights
         }
         envelope_attributes = {
           :name => 'Microsoft.ApplicationInsights.' + data_type[0..-5],
-          :time => Time.now.iso8601(7),
+          :time => time || Time.now.iso8601(7),
           :i_key => local_context.instrumentation_key,
           :tags => get_tags(local_context),
           :data => Contracts::Data.new(data_attributes)

--- a/lib/application_insights/telemetry_client.rb
+++ b/lib/application_insights/telemetry_client.rb
@@ -1,6 +1,7 @@
 require_relative 'channel/telemetry_context'
 require_relative 'channel/telemetry_channel'
 require_relative 'channel/contracts/page_view_data'
+require_relative 'channel/contracts/envelope'
 require_relative 'channel/contracts/exception_data'
 require_relative 'channel/contracts/exception_details'
 require_relative 'channel/contracts/event_data'
@@ -218,6 +219,21 @@ module ApplicationInsights
       )
 
       self.channel.write(data, self.context)
+    end
+
+    # Sends a single telemetry.
+    # This is useful in cases like telemetry forwarding, where the data is already in the
+    # format of envelope and only want to leverage the telemetry channel to send data out.
+    # @param [Hash] data the envelope data of the telemetry.
+    def track_envelope(data)
+      envelope = Channel::Contracts::Envelope.new
+      Channel::Contracts::Envelope.json_mappings.each do |attr, name|
+        if data[name]
+          envelope.send(:"#{attr}=", data[name])
+        end
+      end
+
+      self.channel.queue.push(envelope)
     end
 
     # Flushes data in the queue. Data in the queue will be sent either immediately

--- a/lib/application_insights/telemetry_client.rb
+++ b/lib/application_insights/telemetry_client.rb
@@ -51,6 +51,7 @@ module ApplicationInsights
     #   wants attached to this data item. (defaults to: {})
     # @option options [Hash] :measurements the set of custom measurements the
     #   client wants to attach to this data item (defaults to: {})
+    # @option options [String] :time the timestamp of the page view
     def track_page_view(name, url, options={})
       data_attributes = {
         :name => name || 'Null',
@@ -60,7 +61,7 @@ module ApplicationInsights
         :measurements => options[:measurements] || {}
       }
       data = Channel::Contracts::PageViewData.new data_attributes
-      self.channel.write(data, self.context)
+      self.channel.write(data, self.context, options[:time])
     end
 
     # Send information about a single exception that occurred in the application.
@@ -73,6 +74,7 @@ module ApplicationInsights
     #   wants attached to this data item. (defaults to: {})
     # @option options [Hash] :measurements the set of custom measurements the
     #   client wants to attach to this data item (defaults to: {})
+    # @option options [String] :time the timestamp of the exception
     def track_exception(exception, options={})
       return unless exception.is_a? Exception
 
@@ -111,7 +113,7 @@ module ApplicationInsights
         :measurements => options[:measurements] || {}
       )
 
-      self.channel.write(data, self.context)
+      self.channel.write(data, self.context, options[:time])
     end
 
     # Send information about a single event that has occurred in the context of
@@ -123,6 +125,7 @@ module ApplicationInsights
     #   wants attached to this data item. (defaults to: {})
     # @option options [Hash] :measurements the set of custom measurements the
     #   client wants to attach to this data item (defaults to: {})
+    # @option options [String] :time the timestamp of the event
     def track_event(name, options={})
       data = Channel::Contracts::EventData.new(
         :name => name || 'Null',
@@ -130,7 +133,7 @@ module ApplicationInsights
         :measurements => options[:measurements] || {}
       )
 
-      self.channel.write(data, self.context)
+      self.channel.write(data, self.context, options[:time])
     end
 
     # Send information about a single metric data point that was captured for
@@ -153,6 +156,7 @@ module ApplicationInsights
     #   wants attached to this data item. (defaults to: {})
     # @option options [Hash] :measurements the set of custom measurements the
     #   client wants to attach to this data item (defaults to: {})
+    # @option options [String] :time the timestamp of the metric
     def track_metric(name, value, options={})
       data_point = Channel::Contracts::DataPoint.new(
         :name => name || 'Null',
@@ -169,7 +173,7 @@ module ApplicationInsights
         :properties => options[:properties] || {}
       )
 
-      self.channel.write(data, self.context)
+      self.channel.write(data, self.context, options[:time])
     end
 
     # Sends a single trace statement.
@@ -179,6 +183,7 @@ module ApplicationInsights
     #   {Channel::Contracts::EventData} object.
     # @option options [Hash] :properties the set of custom properties the client
     #   wants attached to this data item. (defaults to: {})
+    # @option options [String] :time the timestamp of the trace
     def track_trace(name, severity_level = nil, options={})
       data = Channel::Contracts::MessageData.new(
         :message => name || 'Null',
@@ -186,7 +191,7 @@ module ApplicationInsights
         :properties => options[:properties] || {}
       )
 
-      self.channel.write(data, self.context)
+      self.channel.write(data, self.context, options[:time])
     end
 
     # Sends a single request.
@@ -218,7 +223,7 @@ module ApplicationInsights
         :measurements => options[:measurements] || {}
       )
 
-      self.channel.write(data, self.context)
+      self.channel.write(data, self.context, start_time)
     end
 
     # Sends a single telemetry.

--- a/test/application_insights/channel/test_telemetry_channel.rb
+++ b/test/application_insights/channel/test_telemetry_channel.rb
@@ -3,6 +3,7 @@ require_relative '../../../lib/application_insights/channel/telemetry_context'
 require_relative '../../../lib/application_insights/channel/synchronous_queue'
 require_relative '../../../lib/application_insights/channel/synchronous_sender'
 require 'test/unit'
+require 'time'
 
 include ApplicationInsights::Channel
 
@@ -70,6 +71,24 @@ class TestTelemetryChannel < Test::Unit::TestCase
     assert_not_nil actual.data
     assert_equal 'MockTelemetryItemData', actual.data.base_type
     assert_same expected, actual.data.base_data
+  end
+
+  def test_write_custom_timestamp
+    queue = MockTelemetryChannelQueue.new SynchronousSender.new
+    context = TelemetryContext.new
+    context.instrumentation_key = 'instrumentation key'
+    channel = TelemetryChannel.new context, queue
+    data = MockTelemetryItemData.new
+    timestamp = (Time.now - 5).iso8601(7)
+
+    channel.write data
+    actual = queue.queue[0]
+    assert_not_equal timestamp, actual.time
+
+    channel.write data, nil, timestamp
+    actual = queue.queue[1]
+    assert_equal timestamp, actual.time
+
   end
 end
 

--- a/test/application_insights/test_telemetry_client.rb
+++ b/test/application_insights/test_telemetry_client.rb
@@ -110,6 +110,22 @@ class TestTelemetryClient < Test::Unit::TestCase
     assert_equal expected, actual
   end
 
+  def test_track_envelope_works_as_expected
+    data = {
+      "name" => "request telemetry",
+      "iKey" => "ikey",
+      "tags" => {},
+      "data" => {:baseType => "RequestData"},
+      "extra" => {}
+    }
+    client, sender = self.create_client
+    client.track_envelope data
+    client.flush
+    expected = '[{"ver":1,"name":"request telemetry","sampleRate":100.0,"iKey":"ikey","data":{"baseType":"RequestData"}}]'
+    actual = sender.data_to_send.to_json
+    assert_equal expected, actual
+  end
+
   def create_client
     sender = MockTelemetryClientSender.new
     queue = Channel::SynchronousQueue.new sender

--- a/test/application_insights/test_telemetry_client.rb
+++ b/test/application_insights/test_telemetry_client.rb
@@ -4,6 +4,7 @@ require_relative '../../lib/application_insights/channel/synchronous_queue'
 require_relative '../../lib/application_insights/channel/telemetry_channel'
 require 'json'
 require 'test/unit'
+require 'time'
 
 include ApplicationInsights
 
@@ -60,7 +61,7 @@ class TestTelemetryClient < Test::Unit::TestCase
     assert_equal expected, actual
   end
 
-  def test_track_event_view_works_as_expected
+  def test_track_event_works_as_expected
     client, sender = self.create_client
     client.track_event 'test'
     client.flush
@@ -70,7 +71,7 @@ class TestTelemetryClient < Test::Unit::TestCase
     assert_equal expected, actual
   end
 
-  def test_track_metric_view_works_as_expected
+  def test_track_metric_works_as_expected
     client, sender = self.create_client
     client.track_metric 'test', 42
     client.flush
@@ -80,7 +81,7 @@ class TestTelemetryClient < Test::Unit::TestCase
     assert_equal expected, actual
   end
 
-  def test_track_trace_view_works_as_expected
+  def test_track_trace_works_as_expected
     client, sender = self.create_client
     client.track_trace 'test', Channel::Contracts::SeverityLevel::WARNING
     client.flush
@@ -90,22 +91,38 @@ class TestTelemetryClient < Test::Unit::TestCase
     assert_equal expected, actual
   end
 
-  def test_track_request_view_works_as_expected
+  def test_track_trace_works_as_expected_with_custom_timestamp
+    timestamp = Time.now.iso8601
     client, sender = self.create_client
-    client.track_request 'test', '2015-01-24T23:10:22.7411910-08:00', '0:00:00:02.0000000','200', true
+    client.track_trace 'test', Channel::Contracts::SeverityLevel::WARNING, {:time => timestamp}
     client.flush
-    expected = '[{"ver":1,"name":"Microsoft.ApplicationInsights.Request","time":"TIME_PLACEHOLDER","sampleRate":100.0,"tags":{"ai.internal.sdkVersion":"rb:__version__"},"data":{"baseType":"RequestData","baseData":{"ver":2,"id":"test","startTime":"2015-01-24T23:10:22.7411910-08:00","duration":"0:00:00:02.0000000","responseCode":"200","success":true}}}]'.gsub!(/__version__/, ApplicationInsights::VERSION)
-    sender.data_to_send[0].time = 'TIME_PLACEHOLDER'
+    expected = '[{"ver":1,"name":"Microsoft.ApplicationInsights.Message","time":"__time__","sampleRate":100.0,"tags":{"ai.internal.sdkVersion":"rb:__version__"},"data":{"baseType":"MessageData","baseData":{"ver":2,"message":"test","severityLevel":2}}}]'
+      .gsub!(/__version__/, ApplicationInsights::VERSION)
+      .gsub!(/__time__/, timestamp)
     actual = sender.data_to_send.to_json
     assert_equal expected, actual
   end
 
-  def test_track_request_view_works_as_expected_when_request_is_failed
+  def test_track_request_works_as_expected
+    start_time = Time.now.iso8601
     client, sender = self.create_client
-    client.track_request 'test', '2015-01-24T23:10:22.7411910-08:00', '0:00:00:02.0000000','200', false
+    client.track_request 'test', start_time, '0:00:00:02.0000000','200', true
     client.flush
-    expected = '[{"ver":1,"name":"Microsoft.ApplicationInsights.Request","time":"TIME_PLACEHOLDER","sampleRate":100.0,"tags":{"ai.internal.sdkVersion":"rb:__version__"},"data":{"baseType":"RequestData","baseData":{"ver":2,"id":"test","startTime":"2015-01-24T23:10:22.7411910-08:00","duration":"0:00:00:02.0000000","responseCode":"200","success":false}}}]'.gsub!(/__version__/, ApplicationInsights::VERSION)
-    sender.data_to_send[0].time = 'TIME_PLACEHOLDER'
+    expected = '[{"ver":1,"name":"Microsoft.ApplicationInsights.Request","time":"__time__","sampleRate":100.0,"tags":{"ai.internal.sdkVersion":"rb:__version__"},"data":{"baseType":"RequestData","baseData":{"ver":2,"id":"test","startTime":"__time__","duration":"0:00:00:02.0000000","responseCode":"200","success":true}}}]'
+      .gsub!(/__version__/, ApplicationInsights::VERSION)
+      .gsub!(/__time__/, start_time)
+    actual = sender.data_to_send.to_json
+    assert_equal expected, actual
+  end
+
+  def test_track_request_works_as_expected_when_request_is_failed
+    start_time = Time.now.iso8601
+    client, sender = self.create_client
+    client.track_request 'test', start_time, '0:00:00:02.0000000','200', false
+    client.flush
+    expected = '[{"ver":1,"name":"Microsoft.ApplicationInsights.Request","time":"__time__","sampleRate":100.0,"tags":{"ai.internal.sdkVersion":"rb:__version__"},"data":{"baseType":"RequestData","baseData":{"ver":2,"id":"test","startTime":"__time__","duration":"0:00:00:02.0000000","responseCode":"200","success":false}}}]'
+      .gsub!(/__version__/, ApplicationInsights::VERSION)
+      .gsub!(/__time__/, start_time)
     actual = sender.data_to_send.to_json
     assert_equal expected, actual
   end


### PR DESCRIPTION
1) Add track_envelope method to telemetry client. This is useful in cases like telemetry forwarding (e.g., fluentd, logstash), where the data is already in the format of envelope and only want to leverage the telemetry channel to send data out.
2) Add timestamp as an option in track methods.
3) Report error message if failed to send telemetry.
